### PR TITLE
Feat/notice

### DIFF
--- a/src/main/java/com/example/springproject/controller/NoticeController.java
+++ b/src/main/java/com/example/springproject/controller/NoticeController.java
@@ -1,0 +1,4 @@
+package com.example.springproject.controller;
+
+public class NoticeController {
+}

--- a/src/main/java/com/example/springproject/controller/NoticeController.java
+++ b/src/main/java/com/example/springproject/controller/NoticeController.java
@@ -1,4 +1,26 @@
 package com.example.springproject.controller;
 
+import com.example.springproject.service.NoticeService;
+import com.example.springproject.util.message.Message;
+import com.example.springproject.util.message.StatusEnum;
+import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+@CrossOrigin(origins = "*")
 public class NoticeController {
+    @Autowired
+    NoticeService noticeService;
+
+    @GetMapping("/noticeList")
+    public ResponseEntity findNoticeList(){
+        return new ResponseEntity(new Message(noticeService.findNoticeList(), StatusEnum.OK), HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/example/springproject/dto/NoticeDTO.java
+++ b/src/main/java/com/example/springproject/dto/NoticeDTO.java
@@ -1,6 +1,7 @@
 package com.example.springproject.dto;
 
 import com.example.springproject.entity.Notice;
+import com.example.springproject.entity.User;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,8 +15,9 @@ public class NoticeDTO {
     private String content;
     private int reference;
     private Long userIdx;
+    private String userName;
 
-    public static NoticeDTO toDTO(Notice notice){
+    public static NoticeDTO toDTO(Notice notice, User user){
         NoticeDTO noticeDTO = new NoticeDTO();
         noticeDTO.setIdx(notice.getIdx());
         noticeDTO.setContent(notice.getContent());
@@ -23,6 +25,7 @@ public class NoticeDTO {
         noticeDTO.setReference(notice.getReference());
         noticeDTO.setTitle(notice.getTitle());
         noticeDTO.setUserIdx(notice.getUserIdx().getIdx());
+        noticeDTO.setUserName(user.getName());
 
         return noticeDTO;
     }

--- a/src/main/java/com/example/springproject/dto/NoticeDTO.java
+++ b/src/main/java/com/example/springproject/dto/NoticeDTO.java
@@ -1,5 +1,6 @@
 package com.example.springproject.dto;
 
+import com.example.springproject.entity.Notice;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,4 +15,15 @@ public class NoticeDTO {
     private int reference;
     private Long userIdx;
 
+    public static NoticeDTO toDTO(Notice notice){
+        NoticeDTO noticeDTO = new NoticeDTO();
+        noticeDTO.setIdx(notice.getIdx());
+        noticeDTO.setContent(notice.getContent());
+        noticeDTO.setCreatedTime(notice.getCreatedTime());
+        noticeDTO.setReference(notice.getReference());
+        noticeDTO.setTitle(notice.getTitle());
+        noticeDTO.setUserIdx(notice.getUserIdx().getIdx());
+
+        return noticeDTO;
+    }
 }

--- a/src/main/java/com/example/springproject/dto/NoticeDTO.java
+++ b/src/main/java/com/example/springproject/dto/NoticeDTO.java
@@ -1,0 +1,17 @@
+package com.example.springproject.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter @Setter
+public class NoticeDTO {
+    private Long idx;
+    private LocalDate createdTime;
+    private String title;
+    private String content;
+    private int reference;
+    private Long userIdx;
+
+}

--- a/src/main/java/com/example/springproject/entity/Notice.java
+++ b/src/main/java/com/example/springproject/entity/Notice.java
@@ -1,0 +1,46 @@
+package com.example.springproject.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Getter @Setter
+@NoArgsConstructor
+@Table(name = "notice")
+public class Notice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notice_idx")
+    private Long idx;
+
+    @Column(name = "notice_time")
+    private LocalDate createdTime;
+
+    @Column(name = "notice_title")
+    private String title;
+
+    @Column(name = "notice_content")
+    private String content;
+
+    @Column(name = "notice_reference")
+    private int reference;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_idx")
+    private User userIdx;
+
+    @Builder
+    public Notice(Long idx, LocalDate createdTime, String title, String content, int reference, User userIdx){
+        this.idx = idx;
+        this.createdTime = createdTime;
+        this.title = title;
+        this.content = content;
+        this.reference = reference;
+        this.userIdx = userIdx;
+    }
+}

--- a/src/main/java/com/example/springproject/repository/NoticeRepository.java
+++ b/src/main/java/com/example/springproject/repository/NoticeRepository.java
@@ -1,0 +1,8 @@
+package com.example.springproject.repository;
+
+import com.example.springproject.entity.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+}

--- a/src/main/java/com/example/springproject/service/NoticeService.java
+++ b/src/main/java/com/example/springproject/service/NoticeService.java
@@ -1,21 +1,23 @@
 package com.example.springproject.service;
 
-import com.example.springproject.dto.NoticeDTO;
-import com.example.springproject.entity.Notice;
 import com.example.springproject.repository.NoticeRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class NoticeService {
     @Autowired
     NoticeRepository noticeRepository;
 
-    public List<NoticeDTO> findNoticeList() {
-        List<Notice> notices = noticeRepository.findAll();
-        return notices.stream().map(NoticeDTO::toDTO).collect(Collectors.toList());
-    }
+//    public List<NoticeDTO> findNoticeList() {
+//        List<Notice> notices = noticeRepository.findAll();
+//        List<NoticeDTO> noticeDTOs;
+//        for(Notice notice : notices){
+//            NoticeDTO noticeDTO = new NoticeDTO();
+//            noticeDTO.setUserIdx(notice.getUserIdx().getIdx());
+//
+//
+//        }
+//        return notices.stream().map(NoticeDTO::toDTO).collect(Collectors.toList());
+//    }
 }

--- a/src/main/java/com/example/springproject/service/NoticeService.java
+++ b/src/main/java/com/example/springproject/service/NoticeService.java
@@ -1,0 +1,21 @@
+package com.example.springproject.service;
+
+import com.example.springproject.dto.NoticeDTO;
+import com.example.springproject.entity.Notice;
+import com.example.springproject.repository.NoticeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class NoticeService {
+    @Autowired
+    NoticeRepository noticeRepository;
+
+    public List<NoticeDTO> findNoticeList() {
+        List<Notice> notices = noticeRepository.findAll();
+        return notices.stream().map(NoticeDTO::toDTO).collect(Collectors.toList());
+    }
+}

--- a/src/test/java/com/example/springproject/controller/NoticeControllerTest.java
+++ b/src/test/java/com/example/springproject/controller/NoticeControllerTest.java
@@ -1,0 +1,18 @@
+package com.example.springproject.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+@SpringBootTest
+class NoticeControllerTest {
+
+    @Autowired
+    NoticeController noticeController;
+
+    @Test
+    void findNoticeList() {
+        System.out.println(noticeController.findNoticeList());
+    }
+}


### PR DESCRIPTION
add findNoticeList

Notice 리스트에 각각 사용자의 name을 추가해줘야 한다.

1. 클라리언트가 noticeList를 받은 후, 리스트 각각의 요소에 담겨있는 userIdx로 사용자 정보 조회 API를 한번 더 호출해서 파싱한다.
2. 서버 단에서 API따로 호출하고 한번에 담아서 준다.

1번과 2번 중 2번을 선택하였다.
그래서 User의 정보를 가져오는 API를 만들 예정이다.